### PR TITLE
Fix GetUnknownRequestHeader (return null on inexistent header)

### DIFF
--- a/src/Mono.WebServer.HyperFastCgi/Request.cs
+++ b/src/Mono.WebServer.HyperFastCgi/Request.cs
@@ -86,6 +86,9 @@ namespace Mono.WebServer.HyperFastCgi
 
 		public string GetUnknownRequestHeader (string name)
 		{
+			if (!unknownHeadersDict.ContainsKey(name))
+				return null;
+
 			return unknownHeadersDict [name];
 		}
 


### PR DESCRIPTION
Signed-off-by: Etienne CHAMPETIER etienne.champetier@fiducial.net
