### PR TITLE
Adding a link to wiki page for examples of Nginx configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ Adds trailing slash if path to directory does not end with '/'. Default is 'fals
 This option were added for compatibility with mono-fastcgi-server. For performance reasons it's recommended to use nginx 'rewrite' command instead, i. e.
     rewrite ^([^.]*[^/])$ $1/ permanent;
 
+Nginx configuration
+-------------------
+
+See the [wiki page for examples of how to configure Nginx](https://github.com/xplicit/HyperFastCgi/wiki/Nginx-configuration)
+
 Additional Info
 ------------
 


### PR DESCRIPTION
The cloned wiki repository with changed wiki page is https://github.com/cvetomirtodorov/HyperFastCgi.wiki.clone
