### PR TITLE
Better handling of server variables and headers

### DIFF
--- a/src/Mono.WebServer.HyperFastCgi/Properties/AssemblyInfo.cs
+++ b/src/Mono.WebServer.HyperFastCgi/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 #if NET_2_0
 [assembly: AssemblyVersion ("0.3.2.0")]
 #else
-[assembly: AssemblyVersion ("0.3.4.0")]
+[assembly: AssemblyVersion ("0.3.5.0")]
 #endif
 
 // The following attributes are used to specify the signing key for the assembly,

--- a/src/Mono.WebServer.HyperFastCgi/scripts/Makefile.am
+++ b/src/Mono.WebServer.HyperFastCgi/scripts/Makefile.am
@@ -16,12 +16,16 @@ $(eval $(call emit-deploy-wrapper,MONO_WEBSERVER_HYPERFASTCGI2,mono-server-hyper
 
 binaries = 
 
+HFC_NAMES = 
+
 if NET_2_0
 MONO_WEBSERVER_HYPERFASTCGI2 = 
+HFC_NAMES += mono-server-hyperfastcgi2
 endif
 
 if NET_4_0
 MONO_WEBSERVER_HYPERFASTCGI4 = 
+HFC_NAMES += mono-server-hyperfastcgi4
 endif
 
 
@@ -29,7 +33,7 @@ BINARIES = $(MONO_WEBSERVER_HYPERFASTCGI2) $(MONO_WEBSERVER_HYPERFASTCGI4)
 
 CLEANFILES = $(BINARIES) 
 
-bin_SCRIPTS = mono-server-hyperfastcgi2 mono-server-hyperfastcgi4
+bin_SCRIPTS = $(HFC_NAMES)
 
 all: $(BINARIES)
 	echo -e 'bin' $(BINARIES)


### PR DESCRIPTION
- throw exception with duplicate servervariable name to make it easier to identify issues
- added method to easily identify servervariable vs standard header, since used in multiple places now
- for headers, don't break if duplicates are received, instead concatenate them

Fix for issue https://github.com/xplicit/HyperFastCgi/issues/42 and better error message for https://github.com/xplicit/HyperFastCgi/issues/18